### PR TITLE
Fix docstring typo

### DIFF
--- a/kernel-coder/utils.py
+++ b/kernel-coder/utils.py
@@ -120,7 +120,7 @@ def log_softmax_and_gather(logits: torch.Tensor, index: torch.Tensor) -> torch.T
 
     torch compiled version of the common `log_softmax -> gather` operation.
 
-    The compiled version of this opration avoids the (significant) memory overhead of
+    The compiled version of this operation avoids the (significant) memory overhead of
     allocating a new (batch_size, seq_len, vocab_size) tensor to store the logprobs.
 
     Args:


### PR DESCRIPTION
## Summary
- fix typo in utils.log_softmax_and_gather docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846157eb058832c8d6f0ad7482b16ab