### PR TITLE
Fix KernelLLM REPL prompt

### DIFF
--- a/scripts/kernelllm.py
+++ b/scripts/kernelllm.py
@@ -318,7 +318,7 @@ class KernelLLM:
             if not code:
                 print(f"Using default prompt:\n{DEFAULT_MODEL_CODE}\n")
                 code = DEFAULT_MODEL_CODE
-            prompt = PROMPT_TEMPLATE.format(DEFAULT_MODEL_CODE)
+            prompt = PROMPT_TEMPLATE.format(code)
 
             try:
                 self.stream_raw(prompt)


### PR DESCRIPTION
## Summary
- update `run_repl` prompt to use user-provided code when available

## Testing
- `python -m py_compile scripts/kernelllm.py`

------
https://chatgpt.com/codex/tasks/task_e_684615b8df18832c8b7906b15cd2df3c